### PR TITLE
Fix bug with explicit or absent 'base' form

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,7 @@ const pokemon = require('pokemon')
 const data = require('./data/data')
 
 function getResult (o, id, name, forme) {
-  if (!('base' in o)) {
-    throw new Error(`No.${id} ${name} does not have normal forme.`)
-  }
-
-  if (forme) {
+  if (forme && forme != 'base') {
     if (!o.otherForme || !o.otherForme[forme]) {
       throw new Error(`No.${id} ${name} does not have '${forme}' forme.`)
     }
@@ -14,6 +10,9 @@ function getResult (o, id, name, forme) {
     return o.otherForme[forme]
   }
 
+  if (!('base' in o)) {
+    throw new Error(`No.${id} ${name} does not have base forme.`)
+  }
   return o.base
 }
 

--- a/test.js
+++ b/test.js
@@ -8,19 +8,27 @@ let hoopaFormes = ['confined', 'unbound']
 
 test('Get stats by IDs', t => {
   t.deepEqual(main.getById({ id: 6 }), baseStats)
+  t.deepEqual(main.getById({ id: 6, forme: 'base'}), baseStats)
   t.deepEqual(main.getById({ id: 6, lang: 'ja' }), baseStats)
   t.deepEqual(main.getById({ id: 6, forme: 'megaX' }), megaStats)
   t.deepEqual(main.getById({ id: 6, forme: 'megaX', lang: 'zh-Hans' }), megaStats)
   t.deepEqual(main.getById({ id: 6, forme: 'megaX', lang: 'de' }), megaStats)
+
+  t.throws(() => main.getById({ id: 720 }), /does not have base forme/)
+  t.notThrows(() => main.getById({ id: 720, forme: 'confined'}))
 })
 
 test('Get stats by Names', t => {
   t.deepEqual(main.getByName({ name: 'Charizard' }), baseStats)
+  t.deepEqual(main.getByName({ name: 'Charizard', forme: 'base'}), baseStats)
   t.deepEqual(main.getByName({ name: 'Чаризард', lang: 'ru' }), baseStats)
   t.deepEqual(main.getByName({ name: '喷火龙',    lang: 'zh-Hans' }), baseStats)
   t.deepEqual(main.getByName({ name: 'Charizard', forme: 'megaX' }), megaStats)
   t.deepEqual(main.getByName({ name: '喷火龙',     forme: 'megaX', lang: 'zh-Hans' }), megaStats)
   t.deepEqual(main.getByName({ name: 'Dracaufeu', forme: 'megaX', lang: 'fr' }), megaStats)
+
+  t.throws(() => main.getByName({ name: 'Hoopa' }), /does not have base forme/)
+  t.notThrows(() => main.getByName({ name: 'Hoopa', forme: 'confined'}))
 })
 
 test ('Get formes', t => {


### PR DESCRIPTION
Either when an explicit 'base' form was requested or the Pokemon
didn't have a base form (even though another form could have been
requested), an exception was thrown. Fixing the logic in getResult.

Missed this one on the first PR, sorry for the spam!